### PR TITLE
Add configurable cleanup delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,9 @@ This plugin cleans old daily notes by applying a set of transformations:
 - Remove code blocks starting with `tasks`.
 - Remove empty sections (a heading followed by only blank lines).
 
+Notes are only cleaned if their filename contains a `YYYY-MM-DD` date that is
+older than a configurable number of days (defaults to **7**). The cleanup runs
+automatically once a day and can also be triggered manually from the command
+palette using **Clean old daily notes**.
+
 Run `npm run build` to compile.


### PR DESCRIPTION
## Summary
- add a `daysAfter` setting with default 7 days
- skip cleaning of daily notes newer than the configured age
- run the cleanup automatically once per day
- expose configuration UI for the age setting
- document automatic cleanup and age setting

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e2e0e7c8c83338552b92c42795c9d